### PR TITLE
In Arch Linux, RAUC is in [extra], not in [community]

### DIFF
--- a/content/pages/index.html
+++ b/content/pages/index.html
@@ -125,10 +125,10 @@
       <div class="row">
         <div class="col-sm-4 opt-item">
           <div style="height:75px;">
-            <img class="img-responsive center-block" style="max-height:100%;" alt="ArchLinux logo" src="images/archlinux-logo.png"/>
+            <img class="img-responsive center-block" style="max-height:100%;" alt="Arch Linux logo" src="images/archlinux-logo.png"/>
           </div>
           <div class="caption">
-            <p>ArchLinux provides a <a href="https://archlinux.org/packages/community/x86_64/rauc/" target="_blank">RAUC package</a></p>
+            <p>Arch Linux provides a <a href="https://archlinux.org/packages/extra/x86_64/rauc/" target="_blank">RAUC package</a></p>
           </div>
         </div>
         <div class="col-sm-4 opt-item">


### PR DESCRIPTION
Also it's "Arch Linux", not "ArchLinux".